### PR TITLE
Fix build issues on Rocky 9 and S3DF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+include src/arch-detect.mak
 -include config.mak
 
 SRCDIR = src

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,10 @@
 Release notes for the LLRF AMC card low level driver.
 
 ## Releases:
+* __R1.1.1__: 2025-10-13 Jeremy Lorelli
+  * Update to CPSW R4.5.2
+  * Makefile adjustments for S3DF
+
 * __R1.1.0__: 2024-04-25 Dawood Alnajjar
   * Corrected Dac38J84 lock bug
 

--- a/config.mak
+++ b/config.mak
@@ -6,8 +6,8 @@ LIB_NAME = llrfAmc
 #####################
 ### Arch Versions ###
 #####################
-# Host version
-HARCH      = rhel6
+# Host versions
+HARCH=$(HOST_ARCH)
 # Buildroot versions
 BR_ARCHES += buildroot-2019.08
 
@@ -18,16 +18,38 @@ CPSW_VERSION     = R4.4.1
 BOOST_VERSION    = 1.64.0
 YAML_CPP_VERSION = yaml-cpp-0.5.3_boost-1.64.0
 
+# RPC symbols were removed from glibc 2.26+
+USE_TIRPC_rhel9  = YES
+USE_TIRPC_rhel8  = YES
+
+################################
+### Default path definitions ###
+################################
+
+# Set a default location for the buildroot toolchain. Allow override on the command line/environment
+ifeq ($(BUILDROOT_HOME),)
+ifneq ($(EPICS_PACKAGE_TOP),)
+BUILDROOT_HOME=$(EPICS_PACKAGE_TOP)/linuxRT/$(BR_VERSION)
+else
+BUILDROOT_HOME=/afs/slac/package/linuxRT/$(BR_VERSION)
+endif
+endif
+
+# Set PACKAGE_TOP to EPICS_PACKAGE_TOP, if not provided
+ifeq ($(PACKAGE_TOP),)
+ifneq ($(EPICS_PACKAGE_TOP),)
+PACKAGE_TOP=$(EPICS_PACKAGE_TOP)
+else
+$(error PACKAGE_TOP or EPICS_PACKAGE_TOP must be provided in the environment or on the command line)
+endif
+endif
+
 ########################
 ### Path definitions ###
 ########################
-# Location of BuildRoot home:
-BUILDROOT_HOME=/afs/slac/package/linuxRT/$(BR_VERSION)
 # Location CrossCompiler HOME:
 XCROSS_HOME=$(BUILDROOT_HOME)/host/linux-x86_64/x86_64/usr/bin/x86_64-buildroot-linux-gnu-
 
-# Package top
-PACKAGE_TOP      = /afs/slac/g/lcls/package
 # Packages location
 CPSW_DIR         = $(PACKAGE_TOP)/cpsw/framework/$(CPSW_VERSION)/$(TARCH)
 BOOST_DIR        = $(PACKAGE_TOP)/boost/$(BOOST_VERSION)/$(TARCH)

--- a/config.mak
+++ b/config.mak
@@ -14,7 +14,7 @@ BR_ARCHES += buildroot-2019.08
 ########################
 ### Package versions ###
 ########################
-CPSW_VERSION     = R4.4.1
+CPSW_VERSION     = R4.5.2
 BOOST_VERSION    = 1.64.0
 YAML_CPP_VERSION = yaml-cpp-0.5.3_boost-1.64.0
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,9 +3,11 @@
 ifdef BR_VERSION
 	CXX	     = $(XCROSS_HOME)g++
 	TARCH    = $(BR_VERSION)-x86_64
+	TVERS    = $(BR_VERSION)
 else
 	CXX    = g++
 	TARCH  = $(H_VERSION)-x86_64
+	TVERS  = $(H_VERSION)
 endif
 
 OBJDIR   = O.$(TARCH)
@@ -28,14 +30,36 @@ TEST_TARGET = $(patsubst $(TESTDIR)/%.cpp, $(TESTBINDIR)/%, $(TESTSRCS))
 CXXFLAGS  = -g -std=c++0x -fPIC
 CXXFLAGS += $(addprefix -I,. $(CPSW_DIR)/include $(BOOST_DIR)/include $(YAML_CPP_DIR)/include)
 
-LIBS_EXT = $(addprefix -l,$(LIB_NAME) cpsw yaml-cpp boost_system rt dl)
+LIBS_EXT = $(addprefix -l,$(LIB_NAME) cpsw yaml-cpp boost_system)
 LIBS_SYS = -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -lrt -ldl
+
+# For host builds, statically link everything except libstdc++, rt, dl, and tirpc (if used)
+ifeq ($(TVERS),$(H_VERSION))
+LIBS_EXT := -Wl,-Bstatic $(LIBS_EXT) -Wl,-Bdynamic
+else
+LIBS_EXT := -static $(LIBS_EXT)
+endif
 
 LDIR  = -L.
 LDIR += -L$(CPSW_DIR)/lib
 LDIR += -L$(BOOST_DIR)/lib
 LDIR += -L$(YAML_CPP_DIR)/lib
 LDIR += -L$(LIBDIR)
+
+TIRPC_INC_default=/usr/include/tirpc
+
+ifeq ($(USE_TIRPC),YES)
+USE_TIRPC_$(TVERS)=YES
+endif
+
+ifeq ($(TIRPC_INC_$(TVERS)),)
+TIRPC_INC_$(TVERS):=$(TIRPC_INC_default)
+endif
+
+ifeq ($(USE_TIRPC_$(TVERS)),YES)
+LIBS_SYS += -ltirpc
+CXXFLAGS += -I$(TIRPC_INC_$(TVERS))
+endif
 
 .PHONY: all clean insatll uninstall
 
@@ -61,7 +85,7 @@ $(TESTBINDIR):
 	@mkdir -p $@
 
 $(TESTBINDIR)/%: $(TESTDIR)/%.cpp
-	$(CXX) -o $@ $^ -static $(CXXFLAGS) $(LDIR) $(LIBS_EXT) $(LIBS_SYS)
+	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDIR) $(LIBS_EXT) $(LIBS_SYS)
 
 clean:
 	$(RM) -rf $(OBJDIR)

--- a/src/arch-detect.mak
+++ b/src/arch-detect.mak
@@ -1,0 +1,11 @@
+#=================================================#
+# Simple utility script to detect host arch
+#=================================================#
+
+HOST_ARCH:=$(shell uname -r | grep -Eo "el[0-9][0-9]?")
+ifneq ($(HOST_ARCH),)
+	HOST_ARCH:=rhel$(subst el,,$(HOST_ARCH))
+else
+	HOST_ARCH:=linux
+endif
+


### PR DESCRIPTION
* Allow PACKAGE_TOP and EPICS_PACKAGE_TOP to specify where the toolchains/packages are located
* Automatically detect host platform. This is based on similar code I wrote for CPSW
* Link against tirpc on rhel8+ and add variables for controlling this
* Don't statically link libstdc++, libc, libdl, librt or libtirpc on host builds. This is largely a workaround for libtirpc not being available as a static library through the system package manager.
* Update to CPSW R4.5.2

Confirmed working on rhel7 and rhel9 both in S3DF and the AFS environment.

rhel7 now dynamically linked:
```
$ ldd rhel7-x86_64/bin/llrf 
        linux-vdso.so.1 =>  (0x00007fffb5ad6000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f2c522a4000)
        librt.so.1 => /lib64/librt.so.1 (0x00007f2c5209c000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007f2c51e98000)
        libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007f2c51b90000)
        libm.so.6 => /lib64/libm.so.6 (0x00007f2c5188e000)
        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f2c51678000)
        libc.so.6 => /lib64/libc.so.6 (0x00007f2c512aa000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f2c524c0000)
```

buildroot still statically linked:
```
$ ldd buildroot-2019.08-x86_64/bin/llrf 
        not a dynamic executable
```